### PR TITLE
Fix archon-first-proof Level 2; add comparator diagnostic tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ export LANDRUN_BIN=/path/to/landrun  # optional
 1. Import only from Mathlib and other spec files within the same entry
 2. Mirror impl module structure: export definitions into separate spec files matching the impl's module layout
 3. Spec files for definitions are SafeVerify-checked against their corresponding impl oleans, just like theorem specs
-4. Theorem statements end with `:= by sorry`
+4. Theorem statements end with `:= by sorry` — with one exception, see rule 9
 5. Match the impl's universe variables exactly (e.g., `universe u v` if the impl uses explicit universes)
 6. Avoid `local notation` — it creates private declarations that won't match the impl's
 7. Each spec module must `lake build` cleanly; spec modules are built individually (not combined)
 8. Human-vetted by a maintainer for mathematical correctness
+9. **Transitive-dep exception**: if a spec definition uses `.choose` (or otherwise references the proof term) of a lemma, the Comparator's Phase 2 check compares that lemma's full `ConstantInfo` including its proof value. A spec `sorry` will never match the impl's real proof, so in that case the lemma's proof must be replicated in the spec. Keep it short and mathematically straightforward — sign-off reviewers need to check the proof manually. Additionally, match the impl's transitive imports (e.g. `Mathlib.RingTheory.SimpleRing.Principal`) so typeclass resolution picks the same instance paths the impl does; otherwise `Expr` terms will differ structurally even when types agree. Example: `extract_ordered_real_roots` in `specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean`.
 
 ## Security Model
 

--- a/scripts/lib/canonical_const_diff.py
+++ b/scripts/lib/canonical_const_diff.py
@@ -94,9 +94,19 @@ def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200):
         return f"#{idx}"
     e = exprs[idx]
     if "bvar" in e:
-        return f"#bvar{e['bvar'].get('id', '?')}"
+        b = e["bvar"]
+        if isinstance(b, int):
+            return f"#bvar{b}"
+        return f"#bvar{b.get('id', '?')}"
     if "sort" in e:
-        return f"(Sort {resolve_level(levels, e['sort'].get('univ', 0))})"
+        s = e["sort"]
+        if isinstance(s, int):
+            return f"(Sort {resolve_level(levels, s)})"
+        return f"(Sort {resolve_level(levels, s.get('univ', 0))})"
+    if "fvar" in e:
+        return f"#fvar{e['fvar']}"
+    if "mvar" in e:
+        return f"#mvar{e['mvar']}"
     if "const" in e:
         c = e["const"]
         name = resolve_name(names, c["name"])

--- a/scripts/lib/canonical_const_diff.py
+++ b/scripts/lib/canonical_const_diff.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Parse two lean4export NDJSON files, extract the ConstantInfo for a given name,
+resolve indices to names, and output canonical forms for diffing.
+
+Usage: canonical_const_diff.py <const_name> <spec_export> <impl_export>
+
+Prints canonical form from each side, then a diff.
+"""
+from __future__ import annotations
+import json
+import sys
+from difflib import unified_diff
+
+
+def parse_export(path):
+    """Parse NDJSON, return (name_table, expr_table, thm_entries, def_entries, ax_entries)."""
+    names = {}   # idx -> (pre_idx, str_or_num)
+    exprs = {}   # idx -> expr_obj
+    levels = {}  # idx -> level_obj
+    thms = []    # list of thm dicts
+    defs = []    # list of def dicts
+    axs = []     # list of ax dicts
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "in" in obj:
+                idx = obj["in"]
+                if "str" in obj:
+                    names[idx] = (obj["str"].get("pre", 0), obj["str"].get("str", ""))
+                elif "num" in obj:
+                    names[idx] = (obj["num"].get("pre", 0), str(obj["num"].get("i", "")))
+            if "ie" in obj:
+                exprs[obj["ie"]] = obj
+            if "iu" in obj:
+                levels[obj["iu"]] = obj
+            if "thm" in obj:
+                thms.append(obj["thm"])
+            if "def" in obj:
+                defs.append(obj["def"])
+            if "ax" in obj:
+                axs.append(obj["ax"])
+    return names, exprs, levels, thms, defs, axs
+
+
+def resolve_name(names, idx):
+    """Resolve a name index to a dotted string."""
+    parts = []
+    seen = set()
+    while idx in names and idx not in seen:
+        seen.add(idx)
+        pre, s = names[idx]
+        parts.append(s)
+        idx = pre
+    parts.reverse()
+    return ".".join(parts) if parts else f"<anon:{idx}>"
+
+
+def resolve_level(levels, idx):
+    """Resolve a level index to a string representation."""
+    if idx == 0:
+        return "0"
+    if idx not in levels:
+        return f"<level:{idx}>"
+    obj = levels[idx]
+    if "us" in obj:
+        return f"(succ {resolve_level(levels, obj['us'].get('pred', 0))})"
+    if "um" in obj:
+        return f"(max {resolve_level(levels, obj['um']['lhs'])} {resolve_level(levels, obj['um']['rhs'])})"
+    if "uim" in obj:
+        return f"(imax {resolve_level(levels, obj['uim']['lhs'])} {resolve_level(levels, obj['uim']['rhs'])})"
+    if "up" in obj:
+        # universe param
+        return f"@{obj['up'].get('name', 0)}"
+    return f"<level:{idx}>"
+
+
+def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200):
+    """Recursively convert an expression to a canonical string form.
+
+    Names are resolved; bound variable names are preserved; structure is made
+    explicit. Output is Lisp-like for easy visual diffing.
+    """
+    if depth > max_depth:
+        return "<...>"
+    if idx not in exprs:
+        # Bound variables (de Bruijn indices) show up as raw numbers
+        return f"#{idx}"
+    e = exprs[idx]
+    if "bvar" in e:
+        return f"#bvar{e['bvar'].get('id', '?')}"
+    if "sort" in e:
+        return f"(Sort {resolve_level(levels, e['sort'].get('univ', 0))})"
+    if "const" in e:
+        c = e["const"]
+        name = resolve_name(names, c["name"])
+        us = " ".join(resolve_level(levels, u) for u in c.get("us", []))
+        if us:
+            return f"(Const {name} {{{us}}})"
+        return f"(Const {name})"
+    if "app" in e:
+        fn = canonical_expr(names, exprs, levels, e["app"]["fn"], depth + 1, max_depth)
+        arg = canonical_expr(names, exprs, levels, e["app"]["arg"], depth + 1, max_depth)
+        return f"(App {fn} {arg})"
+    if "lam" in e:
+        bi = e["lam"].get("binderInfo", "default")
+        nm = resolve_name(names, e["lam"].get("name", 0))
+        ty = canonical_expr(names, exprs, levels, e["lam"]["type"], depth + 1, max_depth)
+        body = canonical_expr(names, exprs, levels, e["lam"]["body"], depth + 1, max_depth)
+        return f"(Lam [{bi}] {nm} : {ty} => {body})"
+    if "forallE" in e:
+        bi = e["forallE"].get("binderInfo", "default")
+        nm = resolve_name(names, e["forallE"].get("name", 0))
+        ty = canonical_expr(names, exprs, levels, e["forallE"]["type"], depth + 1, max_depth)
+        body = canonical_expr(names, exprs, levels, e["forallE"]["body"], depth + 1, max_depth)
+        return f"(Pi [{bi}] {nm} : {ty} -> {body})"
+    if "letE" in e:
+        nm = resolve_name(names, e["letE"].get("name", 0))
+        ty = canonical_expr(names, exprs, levels, e["letE"]["type"], depth + 1, max_depth)
+        val = canonical_expr(names, exprs, levels, e["letE"]["value"], depth + 1, max_depth)
+        body = canonical_expr(names, exprs, levels, e["letE"]["body"], depth + 1, max_depth)
+        return f"(Let {nm} : {ty} := {val} in {body})"
+    if "lit" in e:
+        lit = e["lit"]
+        if "n" in lit:
+            return f"(Lit {lit['n']})"
+        if "s" in lit:
+            return f"(LitStr {lit['s']!r})"
+    if "proj" in e:
+        p = e["proj"]
+        s = canonical_expr(names, exprs, levels, p["struct"], depth + 1, max_depth)
+        return f"(Proj {resolve_name(names, p.get('typeName', 0))} #{p.get('idx', '?')} {s})"
+    if "mdata" in e:
+        return canonical_expr(names, exprs, levels, e["mdata"]["expr"], depth + 1, max_depth)
+    return f"<unknown:{list(e.keys())}>"
+
+
+def canonicalize_const(names, exprs, levels, thms, defs, target_name):
+    """Find the constant by name and return a canonical description."""
+    for thm in thms:
+        if resolve_name(names, thm["name"]) == target_name:
+            lp = [f"@{p}" for p in thm.get("levelParams", [])]
+            ty = canonical_expr(names, exprs, levels, thm["type"])
+            val = canonical_expr(names, exprs, levels, thm.get("value", 0))
+            return (f"KIND: thm\n"
+                    f"LEVEL_PARAMS: {lp}\n"
+                    f"TYPE:\n  {ty}\n"
+                    f"VALUE:\n  {val}\n")
+    for d in defs:
+        if resolve_name(names, d["name"]) == target_name:
+            lp = [f"@{p}" for p in d.get("levelParams", [])]
+            ty = canonical_expr(names, exprs, levels, d["type"])
+            val = canonical_expr(names, exprs, levels, d.get("value", 0))
+            safety = d.get("safety", "unsafe?")
+            hints = d.get("hints", "?")
+            return (f"KIND: def\n"
+                    f"LEVEL_PARAMS: {lp}\n"
+                    f"SAFETY: {safety}\n"
+                    f"HINTS: {hints}\n"
+                    f"TYPE:\n  {ty}\n"
+                    f"VALUE:\n  {val}\n")
+    return None
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <const_name> <spec_export> <impl_export>",
+              file=sys.stderr)
+        sys.exit(2)
+
+    target, spec_path, impl_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    print(f"Loading spec export: {spec_path}", file=sys.stderr)
+    spec_data = parse_export(spec_path)
+    print(f"Loading impl export: {impl_path}", file=sys.stderr)
+    impl_data = parse_export(impl_path)
+
+    spec_names, spec_exprs, spec_levels, spec_thms, spec_defs, _ = spec_data
+    impl_names, impl_exprs, impl_levels, impl_thms, impl_defs, _ = impl_data
+
+    spec_canon = canonicalize_const(spec_names, spec_exprs, spec_levels,
+                                    spec_thms, spec_defs, target)
+    impl_canon = canonicalize_const(impl_names, impl_exprs, impl_levels,
+                                    impl_thms, impl_defs, target)
+
+    if spec_canon is None:
+        print(f"FATAL: '{target}' not found in spec export", file=sys.stderr)
+        sys.exit(1)
+    if impl_canon is None:
+        print(f"FATAL: '{target}' not found in impl export", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"=== SPEC canonical form of {target} ===")
+    print(spec_canon)
+    print(f"=== IMPL canonical form of {target} ===")
+    print(impl_canon)
+    print(f"=== UNIFIED DIFF (spec -> impl) ===")
+    for line in unified_diff(
+            spec_canon.splitlines(keepends=True),
+            impl_canon.splitlines(keepends=True),
+            fromfile="spec", tofile="impl", lineterm=""):
+        print(line.rstrip("\n"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/canonical_const_diff.py
+++ b/scripts/lib/canonical_const_diff.py
@@ -217,15 +217,17 @@ def main():
         print(f"FATAL: '{target}' not found in impl export", file=sys.stderr)
         sys.exit(1)
 
-    print(f"=== SPEC canonical form of {target} ===")
-    print(spec_canon)
-    print(f"=== IMPL canonical form of {target} ===")
-    print(impl_canon)
-    print(f"=== UNIFIED DIFF (spec -> impl) ===")
-    for line in unified_diff(
-            spec_canon.splitlines(keepends=True),
-            impl_canon.splitlines(keepends=True),
-            fromfile="spec", tofile="impl", lineterm=""):
+    print(f"=== UNIFIED DIFF (spec vs impl) for {target} ===")
+    spec_lines = spec_canon.splitlines(keepends=True)
+    impl_lines = impl_canon.splitlines(keepends=True)
+    print(f"Spec canonical form: {len(spec_lines)} lines")
+    print(f"Impl canonical form: {len(impl_lines)} lines")
+    diff_lines = list(unified_diff(
+        spec_lines, impl_lines,
+        fromfile="spec", tofile="impl", n=3, lineterm=""))
+    print(f"Diff lines: {len(diff_lines)}")
+    print("")
+    for line in diff_lines:
         print(line.rstrip("\n"))
 
 

--- a/scripts/lib/canonical_const_diff.py
+++ b/scripts/lib/canonical_const_diff.py
@@ -81,12 +81,14 @@ def resolve_level(levels, idx):
     return f"<level:{idx}>"
 
 
-def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200):
+def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200, indent_level=0):
     """Recursively convert an expression to a canonical string form.
 
     Names are resolved; bound variable names are preserved; structure is made
-    explicit. Output is Lisp-like for easy visual diffing.
+    explicit. Output is Lisp-like, pretty-printed with one line per Pi/Lam/App-spine
+    element so the diff localizes the actual divergence.
     """
+    ind = "  " * (indent_level + 1)
     if depth > max_depth:
         return "<...>"
     if idx not in exprs:
@@ -115,27 +117,36 @@ def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200):
             return f"(Const {name} {{{us}}})"
         return f"(Const {name})"
     if "app" in e:
-        fn = canonical_expr(names, exprs, levels, e["app"]["fn"], depth + 1, max_depth)
-        arg = canonical_expr(names, exprs, levels, e["app"]["arg"], depth + 1, max_depth)
-        return f"(App {fn} {arg})"
+        # Flatten left-associative App chains for readability
+        spine = []
+        cur_idx = idx
+        while cur_idx in exprs and "app" in exprs[cur_idx]:
+            spine.append(exprs[cur_idx]["app"]["arg"])
+            cur_idx = exprs[cur_idx]["app"]["fn"]
+        head = canonical_expr(names, exprs, levels, cur_idx, depth + 1, max_depth, indent_level + 1)
+        args = [canonical_expr(names, exprs, levels, a, depth + 1, max_depth, indent_level + 1)
+                for a in reversed(spine)]
+        if len(args) <= 1 and all(len(a) < 60 for a in args) and len(head) < 60:
+            return f"(App {head} {' '.join(args)})"
+        return "(App " + head + "\n" + "\n".join(ind + a for a in args) + ")"
     if "lam" in e:
         bi = e["lam"].get("binderInfo", "default")
         nm = resolve_name(names, e["lam"].get("name", 0))
-        ty = canonical_expr(names, exprs, levels, e["lam"]["type"], depth + 1, max_depth)
-        body = canonical_expr(names, exprs, levels, e["lam"]["body"], depth + 1, max_depth)
-        return f"(Lam [{bi}] {nm} : {ty} => {body})"
+        ty = canonical_expr(names, exprs, levels, e["lam"]["type"], depth + 1, max_depth, indent_level + 1)
+        body = canonical_expr(names, exprs, levels, e["lam"]["body"], depth + 1, max_depth, indent_level + 1)
+        return f"(Lam [{bi}] {nm} :\n{ind}{ty}\n{ind}=>\n{ind}{body})"
     if "forallE" in e:
         bi = e["forallE"].get("binderInfo", "default")
         nm = resolve_name(names, e["forallE"].get("name", 0))
-        ty = canonical_expr(names, exprs, levels, e["forallE"]["type"], depth + 1, max_depth)
-        body = canonical_expr(names, exprs, levels, e["forallE"]["body"], depth + 1, max_depth)
-        return f"(Pi [{bi}] {nm} : {ty} -> {body})"
+        ty = canonical_expr(names, exprs, levels, e["forallE"]["type"], depth + 1, max_depth, indent_level + 1)
+        body = canonical_expr(names, exprs, levels, e["forallE"]["body"], depth + 1, max_depth, indent_level + 1)
+        return f"(Pi [{bi}] {nm} :\n{ind}{ty}\n{ind}->\n{ind}{body})"
     if "letE" in e:
         nm = resolve_name(names, e["letE"].get("name", 0))
-        ty = canonical_expr(names, exprs, levels, e["letE"]["type"], depth + 1, max_depth)
-        val = canonical_expr(names, exprs, levels, e["letE"]["value"], depth + 1, max_depth)
-        body = canonical_expr(names, exprs, levels, e["letE"]["body"], depth + 1, max_depth)
-        return f"(Let {nm} : {ty} := {val} in {body})"
+        ty = canonical_expr(names, exprs, levels, e["letE"]["type"], depth + 1, max_depth, indent_level + 1)
+        val = canonical_expr(names, exprs, levels, e["letE"]["value"], depth + 1, max_depth, indent_level + 1)
+        body = canonical_expr(names, exprs, levels, e["letE"]["body"], depth + 1, max_depth, indent_level + 1)
+        return f"(Let {nm} :\n{ind}{ty}\n{ind}:=\n{ind}{val}\n{ind}in\n{ind}{body})"
     if "lit" in e:
         lit = e["lit"]
         if "n" in lit:

--- a/scripts/verify_entry.sh
+++ b/scripts/verify_entry.sh
@@ -416,7 +416,8 @@ for ext in ('lakefile.lean', 'lakefile.toml'):
 
             # Run comparator via lake env (sets up LEAN_PATH)
             # Comparator internally uses landrun for sandboxing
-            if (cd "$REPO_DIR" && lake env "$COMPARATOR" "$config") 2>&1; then
+            COMPARATOR_LOG=$(mktemp)
+            if (cd "$REPO_DIR" && lake env "$COMPARATOR" "$config") 2>&1 | tee "$COMPARATOR_LOG"; then
                 echo "  Comparator $config_name: PASS"
                 if [[ -n "$group_idx" ]]; then
                     GROUP_COMPARATOR[$group_idx]="pass"
@@ -427,7 +428,27 @@ for ext in ('lakefile.lean', 'lakefile.toml'):
                     GROUP_COMPARATOR[$group_idx]="fail"
                 fi
                 FAILED=1
+
+                # Diagnostic: if the failure was a const mismatch, dump both
+                # exports so we can see exactly what diverged at the kernel level.
+                FAILING_CONST=$(grep -oP "Const does not match between challenge and target '\K[^']+" "$COMPARATOR_LOG" | head -1)
+                if [[ -n "$FAILING_CONST" ]] && [[ -n "$LEAN4EXPORT" ]] && [[ -f "$LEAN4EXPORT" ]]; then
+                    echo ""
+                    echo "=== DIAGNOSTIC: export diff for $FAILING_CONST ==="
+                    CHALLENGE_MODULE=$(python3 -c "import json; print(json.load(open('$config'))['challenge_module'])" 2>/dev/null)
+                    SOLUTION_MODULE=$(python3 -c "import json; print(json.load(open('$config'))['solution_module'])" 2>/dev/null)
+                    SPEC_OUT=$(mktemp)
+                    IMPL_OUT=$(mktemp)
+                    (cd "$REPO_DIR" && lake env "$LEAN4EXPORT" "$CHALLENGE_MODULE" -- "$FAILING_CONST" > "$SPEC_OUT" 2>&1) || echo "  (spec export failed)"
+                    (cd "$REPO_DIR" && lake env "$LEAN4EXPORT" "$SOLUTION_MODULE" -- "$FAILING_CONST" > "$IMPL_OUT" 2>&1) || echo "  (impl export failed)"
+                    echo "--- Spec export size: $(wc -l < "$SPEC_OUT") lines, Impl export size: $(wc -l < "$IMPL_OUT") lines ---"
+                    echo "--- diff (spec vs impl), truncated to 200 lines ---"
+                    diff -u "$SPEC_OUT" "$IMPL_OUT" | head -200 || true
+                    echo "=== END DIAGNOSTIC ==="
+                    rm -f "$SPEC_OUT" "$IMPL_OUT"
+                fi
             fi
+            rm -f "$COMPARATOR_LOG"
         done
     fi
 fi

--- a/scripts/verify_entry.sh
+++ b/scripts/verify_entry.sh
@@ -444,7 +444,7 @@ for ext in ('lakefile.lean', 'lakefile.toml'):
                     echo "--- Spec export size: $(wc -l < "$SPEC_OUT") lines, Impl export size: $(wc -l < "$IMPL_OUT") lines ---"
                     echo "--- canonical form comparison (names resolved, index noise removed) ---"
                     python3 "$PROJECT_DIR/scripts/lib/canonical_const_diff.py" \
-                        "$FAILING_CONST" "$SPEC_OUT" "$IMPL_OUT" 2>&1 | head -500 || true
+                        "$FAILING_CONST" "$SPEC_OUT" "$IMPL_OUT" 2>&1 | head -3000 || true
                     echo "=== END DIAGNOSTIC ==="
                     rm -f "$SPEC_OUT" "$IMPL_OUT"
                 fi

--- a/scripts/verify_entry.sh
+++ b/scripts/verify_entry.sh
@@ -442,8 +442,9 @@ for ext in ('lakefile.lean', 'lakefile.toml'):
                     (cd "$REPO_DIR" && lake env "$LEAN4EXPORT" "$CHALLENGE_MODULE" -- "$FAILING_CONST" > "$SPEC_OUT" 2>&1) || echo "  (spec export failed)"
                     (cd "$REPO_DIR" && lake env "$LEAN4EXPORT" "$SOLUTION_MODULE" -- "$FAILING_CONST" > "$IMPL_OUT" 2>&1) || echo "  (impl export failed)"
                     echo "--- Spec export size: $(wc -l < "$SPEC_OUT") lines, Impl export size: $(wc -l < "$IMPL_OUT") lines ---"
-                    echo "--- diff (spec vs impl), truncated to 200 lines ---"
-                    diff -u "$SPEC_OUT" "$IMPL_OUT" | head -200 || true
+                    echo "--- canonical form comparison (names resolved, index noise removed) ---"
+                    python3 "$PROJECT_DIR/scripts/lib/canonical_const_diff.py" \
+                        "$FAILING_CONST" "$SPEC_OUT" "$IMPL_OUT" 2>&1 | head -500 || true
                     echo "=== END DIAGNOSTIC ==="
                     rm -f "$SPEC_OUT" "$IMPL_OUT"
                 fi

--- a/specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean
+++ b/specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean
@@ -20,9 +20,13 @@ import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Algebra.Order.Ring.Star
 import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Analysis.CStarAlgebra.Classes
+import Mathlib.Analysis.Complex.Convex
 import Mathlib.Analysis.Complex.Polynomial.GaussLucas
+import Mathlib.Analysis.Polynomial.Basic
 import Mathlib.Analysis.RCLike.Basic
 import Mathlib.Data.Int.Star
+import Mathlib.Data.Real.StarOrdered
+import Mathlib.RingTheory.SimpleRing.Principal
 
 open Polynomial BigOperators Nat Classical
 

--- a/specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean
+++ b/specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean
@@ -68,12 +68,48 @@ def PhiN (roots : Fin n → ℝ) : ℝ :=
 
 /-- Extraction of ordered real roots: if a monic separable polynomial of degree m
     has all complex roots with zero imaginary part, then it has m distinct ordered
-    real roots. -/
+    real roots.
+
+    NOTE: Proof body replicated from the impl (FirstProof.FirstProof4.Auxiliary.SignSquarefree)
+    so that the comparator's transitive Phase 2 check matches. This is a narrow exception
+    to the "spec files use `sorry` only" rule, needed because `invPhiN_poly` uses
+    `extract_ordered_real_roots.choose` in its body — the constant's full ConstantInfo
+    (including proof value) is therefore compared at the kernel level. -/
 lemma extract_ordered_real_roots (f : ℝ[X]) (m : ℕ)
     (hf_monic : f.Monic) (hf_deg : f.natDegree = m)
     (hf_real : ∀ z : ℂ, (f.map (algebraMap ℝ ℂ)).IsRoot z → z.im = 0)
     (hf_sep : Squarefree f) :
-    ∃ (μ : Fin m → ℝ), StrictMono μ ∧ (∀ i, f.IsRoot (μ i)) := by sorry
+    ∃ (μ : Fin m → ℝ), StrictMono μ ∧ (∀ i, f.IsRoot (μ i)) := by
+  have hf_sep' : f.Separable := PerfectField.separable_iff_squarefree.mpr hf_sep
+  have hfc_splits : (f.map (algebraMap ℝ ℂ)).Splits := IsAlgClosed.splits _
+  have hfc_range :
+      ∀ a ∈ (f.map (algebraMap ℝ ℂ)).roots,
+        a ∈ (algebraMap ℝ ℂ).range := by
+    intro z hz
+    have hne : f.map (algebraMap ℝ ℂ) ≠ 0 :=
+      Polynomial.map_ne_zero (Polynomial.Monic.ne_zero hf_monic)
+    have hroot : (f.map (algebraMap ℝ ℂ)).IsRoot z := (Polynomial.mem_roots hne).mp hz
+    have him : z.im = 0 := hf_real z hroot
+    exact ⟨z.re, Complex.ext (by simp [Complex.ofReal_re]) (by simp [him, Complex.ofReal_im])⟩
+  have hf_splits : f.Splits :=
+    hfc_splits.of_splits_map (algebraMap ℝ ℂ) hfc_range
+  have hcard : f.roots.card = m := by
+    rw [← hf_deg]; exact hf_splits.natDegree_eq_card_roots.symm
+  have hnodup : f.roots.Nodup := Polynomial.nodup_roots hf_sep'
+  set L := f.roots.sort (· ≤ ·) with hL_def
+  have hL_length : L.length = m := by rw [Multiset.length_sort, hcard]
+  have hL_sorted_le : L.SortedLE := (Multiset.pairwise_sort f.roots (· ≤ ·)).sortedLE
+  have hL_nodup : L.Nodup := by
+    rw [← Multiset.coe_nodup, Multiset.sort_eq]; exact hnodup
+  have hL_sorted_lt : L.SortedLT := hL_sorted_le.sortedLT_of_nodup hL_nodup
+  have hL_strictMono : StrictMono L.get := hL_sorted_lt.strictMono_get
+  refine ⟨fun i ↦ L.get (i.cast hL_length.symm), ?_, ?_⟩
+  · intro i j hij; exact hL_strictMono (by simpa using hij)
+  · intro i
+    have hmem : L.get (i.cast hL_length.symm) ∈ L := List.get_mem L _
+    have hmem' : L.get (i.cast hL_length.symm) ∈ f.roots := by
+      rwa [← Multiset.mem_sort (r := (· ≤ ·))]
+    rwa [Polynomial.mem_roots (Polynomial.Monic.ne_zero hf_monic)] at hmem'
 
 /-! ### Definition from InvPhiN.lean -/
 


### PR DESCRIPTION
## Summary

- **archon-first-proof problem4** now passes Level 2 (comparator). The failure was a transitive-dep mismatch: `invPhiN_poly` uses `extract_ordered_real_roots.choose`, so the comparator's Phase 2 compares the lemma's full `ConstantInfo`. Spec `sorry` never matches the impl's real proof.
- Fix: replicate the proof body in the spec AND match impl's transitive imports so typeclass synthesis picks the same instance paths (key one: `Mathlib.RingTheory.SimpleRing.Principal` — gives `DivisionRing → IsSimpleRing → IsDomain`).
- Added a diagnostic that, on comparator const-mismatch failure, runs `lean4export` on both sides and prints a name-resolved, pretty-printed canonical diff of the mismatching constant. Saved hours today; will help future cases.
- Documented the exception to the "spec uses sorry only" rule in the README.

## Changes

- `specs/archon-first-proof/Registry/ArchonFirstProof/Problem4.lean`: replicate `extract_ordered_real_roots` proof; add 4 Mathlib imports to match impl
- `scripts/lib/canonical_const_diff.py` (new): parse lean4export NDJSON, resolve indices to names, pretty-print expressions, produce unified diff of target constant
- `scripts/verify_entry.sh`: invoke the diagnostic on comparator const-mismatch
- `README.md`: add rule 9 documenting the transitive-dep exception

## Verification

Triggered Weekly Level 2 on this branch (run 24639984159):
- archon-first-proof: **success** (problem4: PASS, problem6: PASS, Verification passed)

## Test plan

- [x] archon-first-proof Level 2 passes on CI
- [ ] Next scheduled weekly run (Sunday) confirms no regressions on aks / stat-learning / artificial-theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)