### PR TITLE
Fix canonical_const_diff NDJSON field names

### DIFF
--- a/scripts/lib/canonical_const_diff.py
+++ b/scripts/lib/canonical_const_diff.py
@@ -6,6 +6,19 @@ resolve indices to names, and output canonical forms for diffing.
 Usage: canonical_const_diff.py <const_name> <spec_export> <impl_export>
 
 Prints canonical form from each side, then a diff.
+
+Field names follow lean4export 3.1.0 (see leanprover/lean4export's
+``Export.lean`` and ``format_ndjson.md`` on branch ``master``):
+
+    - Names are tagged ``"in"`` with payload under ``"str"`` / ``"num"``.
+    - Levels are tagged ``"il"``; the level kind lives at the top level under
+      ``"succ"`` (int level idx), ``"max"``/``"imax"`` (``[lhs, rhs]`` arrays of
+      level idxs), or ``"param"`` (int *name* idx).
+    - Expressions are tagged ``"ie"``; literals appear top-level as
+      ``"natVal"`` (string of digits) or ``"strVal"`` (string).
+    - Declarations are tagged ``"axiom"``, ``"def"``, ``"thm"``, ``"opaque"``,
+      ``"quot"``, and ``"inductive"`` (the latter aggregates ``types``,
+      ``ctors``, ``recs``).
 """
 from __future__ import annotations
 import json
@@ -14,13 +27,13 @@ from difflib import unified_diff
 
 
 def parse_export(path):
-    """Parse NDJSON, return (name_table, expr_table, thm_entries, def_entries, ax_entries)."""
+    """Parse NDJSON, return (name_table, expr_table, level_table, thm_entries, def_entries, ax_entries)."""
     names = {}   # idx -> (pre_idx, str_or_num)
     exprs = {}   # idx -> expr_obj
     levels = {}  # idx -> level_obj
     thms = []    # list of thm dicts
     defs = []    # list of def dicts
-    axs = []     # list of ax dicts
+    axs = []     # list of axiom dicts
     with open(path) as f:
         for line in f:
             line = line.strip()
@@ -30,22 +43,26 @@ def parse_export(path):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            # Names: tagged with "in"
             if "in" in obj:
                 idx = obj["in"]
                 if "str" in obj:
                     names[idx] = (obj["str"].get("pre", 0), obj["str"].get("str", ""))
                 elif "num" in obj:
                     names[idx] = (obj["num"].get("pre", 0), str(obj["num"].get("i", "")))
+            # Expressions: tagged with "ie"
             if "ie" in obj:
                 exprs[obj["ie"]] = obj
-            if "iu" in obj:
-                levels[obj["iu"]] = obj
+            # Levels: tagged with "il" (NOT "iu" — see Export.lean dumpLevel)
+            if "il" in obj:
+                levels[obj["il"]] = obj
             if "thm" in obj:
                 thms.append(obj["thm"])
             if "def" in obj:
                 defs.append(obj["def"])
-            if "ax" in obj:
-                axs.append(obj["ax"])
+            # Axioms: tagged "axiom" (NOT "ax") per Export.lean dumpAxiomVal
+            if "axiom" in obj:
+                axs.append(obj["axiom"])
     return names, exprs, levels, thms, defs, axs
 
 
@@ -62,22 +79,33 @@ def resolve_name(names, idx):
     return ".".join(parts) if parts else f"<anon:{idx}>"
 
 
-def resolve_level(levels, idx):
-    """Resolve a level index to a string representation."""
+def resolve_level(names, levels, idx):
+    """Resolve a level index to a string representation.
+
+    Per ``Export.lean``, the level kind lives at the top level of the entry:
+    ``succ`` (int level idx), ``max``/``imax`` (``[lhs, rhs]`` array of level
+    idxs), and ``param`` (int *name* idx). Index 0 denotes ``Level.zero``,
+    which is never serialized as its own entry.
+    """
     if idx == 0:
         return "0"
     if idx not in levels:
         return f"<level:{idx}>"
     obj = levels[idx]
-    if "us" in obj:
-        return f"(succ {resolve_level(levels, obj['us'].get('pred', 0))})"
-    if "um" in obj:
-        return f"(max {resolve_level(levels, obj['um']['lhs'])} {resolve_level(levels, obj['um']['rhs'])})"
-    if "uim" in obj:
-        return f"(imax {resolve_level(levels, obj['uim']['lhs'])} {resolve_level(levels, obj['uim']['rhs'])})"
-    if "up" in obj:
-        # universe param
-        return f"@{obj['up'].get('name', 0)}"
+    # "succ": top-level int payload (level idx of predecessor)
+    if "succ" in obj:
+        return f"(succ {resolve_level(names, levels, obj['succ'])})"
+    # "max": top-level [lhs, rhs] array of level idxs
+    if "max" in obj:
+        lhs, rhs = obj["max"]
+        return f"(max {resolve_level(names, levels, lhs)} {resolve_level(names, levels, rhs)})"
+    # "imax": top-level [lhs, rhs] array of level idxs
+    if "imax" in obj:
+        lhs, rhs = obj["imax"]
+        return f"(imax {resolve_level(names, levels, lhs)} {resolve_level(names, levels, rhs)})"
+    # "param": top-level int *name* idx (resolve via name table)
+    if "param" in obj:
+        return f"@{resolve_name(names, obj['param'])}"
     return f"<level:{idx}>"
 
 
@@ -95,29 +123,26 @@ def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200, indent_lev
         # Bound variables (de Bruijn indices) show up as raw numbers
         return f"#{idx}"
     e = exprs[idx]
+    # "bvar": top-level int (de Bruijn index)
     if "bvar" in e:
-        b = e["bvar"]
-        if isinstance(b, int):
-            return f"#bvar{b}"
-        return f"#bvar{b.get('id', '?')}"
+        return f"#bvar{e['bvar']}"
+    # "sort": top-level int level idx
     if "sort" in e:
-        s = e["sort"]
-        if isinstance(s, int):
-            return f"(Sort {resolve_level(levels, s)})"
-        return f"(Sort {resolve_level(levels, s.get('univ', 0))})"
+        return f"(Sort {resolve_level(names, levels, e['sort'])})"
     if "fvar" in e:
         return f"#fvar{e['fvar']}"
     if "mvar" in e:
         return f"#mvar{e['mvar']}"
+    # "const": {"name": int, "us": [level idx, ...]}
     if "const" in e:
         c = e["const"]
         name = resolve_name(names, c["name"])
-        us = " ".join(resolve_level(levels, u) for u in c.get("us", []))
+        us = " ".join(resolve_level(names, levels, u) for u in c.get("us", []))
         if us:
             return f"(Const {name} {{{us}}})"
         return f"(Const {name})"
+    # "app": {"fn": expr idx, "arg": expr idx} — flatten left-assoc spines
     if "app" in e:
-        # Flatten left-associative App chains for readability
         spine = []
         cur_idx = idx
         while cur_idx in exprs and "app" in exprs[cur_idx]:
@@ -129,44 +154,53 @@ def canonical_expr(names, exprs, levels, idx, depth=0, max_depth=200, indent_lev
         if len(args) <= 1 and all(len(a) < 60 for a in args) and len(head) < 60:
             return f"(App {head} {' '.join(args)})"
         return "(App " + head + "\n" + "\n".join(ind + a for a in args) + ")"
+    # "lam": {"name", "type", "body", "binderInfo"}
     if "lam" in e:
         bi = e["lam"].get("binderInfo", "default")
         nm = resolve_name(names, e["lam"].get("name", 0))
         ty = canonical_expr(names, exprs, levels, e["lam"]["type"], depth + 1, max_depth, indent_level + 1)
         body = canonical_expr(names, exprs, levels, e["lam"]["body"], depth + 1, max_depth, indent_level + 1)
         return f"(Lam [{bi}] {nm} :\n{ind}{ty}\n{ind}=>\n{ind}{body})"
+    # "forallE": {"name", "type", "body", "binderInfo"}
     if "forallE" in e:
         bi = e["forallE"].get("binderInfo", "default")
         nm = resolve_name(names, e["forallE"].get("name", 0))
         ty = canonical_expr(names, exprs, levels, e["forallE"]["type"], depth + 1, max_depth, indent_level + 1)
         body = canonical_expr(names, exprs, levels, e["forallE"]["body"], depth + 1, max_depth, indent_level + 1)
         return f"(Pi [{bi}] {nm} :\n{ind}{ty}\n{ind}->\n{ind}{body})"
+    # "letE": {"name", "type", "value", "body", "nondep"}
     if "letE" in e:
         nm = resolve_name(names, e["letE"].get("name", 0))
         ty = canonical_expr(names, exprs, levels, e["letE"]["type"], depth + 1, max_depth, indent_level + 1)
         val = canonical_expr(names, exprs, levels, e["letE"]["value"], depth + 1, max_depth, indent_level + 1)
         body = canonical_expr(names, exprs, levels, e["letE"]["body"], depth + 1, max_depth, indent_level + 1)
         return f"(Let {nm} :\n{ind}{ty}\n{ind}:=\n{ind}{val}\n{ind}in\n{ind}{body})"
-    if "lit" in e:
-        lit = e["lit"]
-        if "n" in lit:
-            return f"(Lit {lit['n']})"
-        if "s" in lit:
-            return f"(LitStr {lit['s']!r})"
+    # Literals: top-level "natVal" (string of digits) or "strVal" (string)
+    if "natVal" in e:
+        return f"(Lit {e['natVal']})"
+    if "strVal" in e:
+        return f"(LitStr {e['strVal']!r})"
+    # "proj": {"typeName": name idx, "idx": int field, "struct": expr idx}
     if "proj" in e:
         p = e["proj"]
-        s = canonical_expr(names, exprs, levels, p["struct"], depth + 1, max_depth)
+        s = canonical_expr(names, exprs, levels, p["struct"], depth + 1, max_depth, indent_level + 1)
         return f"(Proj {resolve_name(names, p.get('typeName', 0))} #{p.get('idx', '?')} {s})"
+    # "mdata": {"data": <opaque>, "expr": expr idx} — transparent for canonical form
     if "mdata" in e:
-        return canonical_expr(names, exprs, levels, e["mdata"]["expr"], depth + 1, max_depth)
-    return f"<unknown:{list(e.keys())}>"
+        return canonical_expr(names, exprs, levels, e["mdata"]["expr"], depth + 1, max_depth, indent_level)
+    return f"<unknown:{sorted(k for k in e.keys() if k != 'ie')}>"
+
+
+def _format_level_params(names, lps):
+    """Render a declaration's ``levelParams`` (list of name indices) as ``@<name>``."""
+    return [f"@{resolve_name(names, p)}" for p in lps]
 
 
 def canonicalize_const(names, exprs, levels, thms, defs, target_name):
     """Find the constant by name and return a canonical description."""
     for thm in thms:
         if resolve_name(names, thm["name"]) == target_name:
-            lp = [f"@{p}" for p in thm.get("levelParams", [])]
+            lp = _format_level_params(names, thm.get("levelParams", []))
             ty = canonical_expr(names, exprs, levels, thm["type"])
             val = canonical_expr(names, exprs, levels, thm.get("value", 0))
             return (f"KIND: thm\n"
@@ -175,7 +209,7 @@ def canonicalize_const(names, exprs, levels, thms, defs, target_name):
                     f"VALUE:\n  {val}\n")
     for d in defs:
         if resolve_name(names, d["name"]) == target_name:
-            lp = [f"@{p}" for p in d.get("levelParams", [])]
+            lp = _format_level_params(names, d.get("levelParams", []))
             ty = canonical_expr(names, exprs, levels, d["type"])
             val = canonical_expr(names, exprs, levels, d.get("value", 0))
             safety = d.get("safety", "unsafe?")

--- a/scripts/lib/test_canonical_const_diff.py
+++ b/scripts/lib/test_canonical_const_diff.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Unit tests for canonical_const_diff.py.
+
+Run: ``python3 scripts/lib/test_canonical_const_diff.py``
+
+No pytest dependency. The synthetic NDJSON fragment below mirrors the lean4export
+3.1.0 schema (see leanprover/lean4export's ``Export.lean`` / ``format_ndjson.md``)
+and exercises:
+
+    * Every Level kind: ``succ``, ``max``, ``imax``, ``param``
+    * Both literal kinds: ``natVal`` and ``strVal``
+    * ``Expr.proj``, ``Expr.mdata``, ``Expr.lam``, ``Expr.forallE``
+    * A ``thm`` declaration whose ``type`` and ``value`` cover all of the above
+
+The asserted invariant: ``canonicalize_const`` must produce output free of
+``<level:N>`` and ``<unknown:...>`` placeholders for every node we exercise.
+"""
+from __future__ import annotations
+import os
+import sys
+import tempfile
+import textwrap
+
+# Ensure we import the sibling module no matter where pytest is invoked from.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from canonical_const_diff import (  # noqa: E402
+    parse_export,
+    resolve_name,
+    resolve_level,
+    canonical_expr,
+    canonicalize_const,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic NDJSON fragment
+# ---------------------------------------------------------------------------
+# Layout (one JSON object per line):
+#
+#   Names (tag "in"):
+#     1: "Foo"                   2: "Foo.bar"        3: "Pair"
+#     4: "Pair.fst"              5: "u"              6: "v"
+#     7: "α"                     8: "x"              9: "y"
+#    10: "List"                 11: "Eq"
+#
+#   Levels (tag "il"):
+#     1: param u                 2: succ 1           3: param v
+#     4: max  1 3                5: imax 1 3
+#
+#   Expressions (tag "ie"):
+#     1: Sort (succ u)               -- uses level idx 2
+#     2: bvar 0
+#     3: Const Pair {max u v}        -- uses level idx 4
+#     4: app (#3) (#1)               -- (Pair (Sort (succ u)))
+#     5: proj Pair #0 of #4
+#     6: mdata wrapping #5
+#     7: natVal "42"
+#     8: strVal "hi"
+#     9: Const Eq {imax u v}         -- uses level idx 5
+#    10: app (#9) (#7)               -- (Eq 42)
+#    11: app (#10) (#8)              -- (Eq 42 "hi"), drives an App spine
+#    12: lam α : (Sort u) => bvar 0  -- identity at type Sort u
+#    13: forallE x : (#1) -> bvar 0  -- ∀ (x : Sort (succ u)), bvar 0
+#    14: letE y : (#1) := #6 in #11  -- ties proj+mdata+lits+app together
+#    15: app (#12) (#14)             -- ((λα. α) (let y := proj … in Eq 42 "hi"))
+#
+#   Theorem (tag "thm"):
+#     name=2 (Foo.bar), levelParams=[5,6], type=#13, value=#15
+
+SYNTHETIC_NDJSON = "\n".join([
+    # Names
+    '{"in":1,"str":{"pre":0,"str":"Foo"}}',
+    '{"in":2,"str":{"pre":1,"str":"bar"}}',
+    '{"in":3,"str":{"pre":0,"str":"Pair"}}',
+    '{"in":4,"str":{"pre":3,"str":"fst"}}',
+    '{"in":5,"str":{"pre":0,"str":"u"}}',
+    '{"in":6,"str":{"pre":0,"str":"v"}}',
+    '{"in":7,"str":{"pre":0,"str":"\\u03b1"}}',
+    '{"in":8,"str":{"pre":0,"str":"x"}}',
+    '{"in":9,"str":{"pre":0,"str":"y"}}',
+    '{"in":10,"str":{"pre":0,"str":"List"}}',
+    '{"in":11,"str":{"pre":0,"str":"Eq"}}',
+
+    # Levels
+    '{"il":1,"param":5}',
+    '{"il":2,"succ":1}',
+    '{"il":3,"param":6}',
+    '{"il":4,"max":[1,3]}',
+    '{"il":5,"imax":[1,3]}',
+
+    # Expressions
+    '{"ie":1,"sort":2}',
+    '{"ie":2,"bvar":0}',
+    '{"ie":3,"const":{"name":3,"us":[4]}}',
+    '{"ie":4,"app":{"fn":3,"arg":1}}',
+    '{"ie":5,"proj":{"typeName":3,"idx":0,"struct":4}}',
+    '{"ie":6,"mdata":{"data":{},"expr":5}}',
+    '{"ie":7,"natVal":"42"}',
+    '{"ie":8,"strVal":"hi"}',
+    '{"ie":9,"const":{"name":11,"us":[5]}}',
+    '{"ie":10,"app":{"fn":9,"arg":7}}',
+    '{"ie":11,"app":{"fn":10,"arg":8}}',
+    '{"ie":12,"lam":{"name":7,"type":1,"body":2,"binderInfo":"default"}}',
+    '{"ie":13,"forallE":{"name":8,"type":1,"body":2,"binderInfo":"default"}}',
+    '{"ie":14,"letE":{"name":9,"type":1,"value":6,"body":11,"nondep":false}}',
+    '{"ie":15,"app":{"fn":12,"arg":14}}',
+
+    # Theorem declaration
+    '{"thm":{"name":2,"levelParams":[5,6],"type":13,"value":15,"all":[2]}}',
+]) + "\n"
+
+
+def _load_synthetic():
+    """Write the synthetic NDJSON to a temp file and parse it."""
+    with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False) as fh:
+        fh.write(SYNTHETIC_NDJSON)
+        path = fh.name
+    try:
+        return parse_export(path)
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def _check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_parse_collects_all_kinds():
+    names, exprs, levels, thms, defs, axs = _load_synthetic()
+    _check(len(names) == 11, f"expected 11 names, got {len(names)}: {sorted(names)}")
+    _check(len(levels) == 5, f"expected 5 levels, got {len(levels)}: {sorted(levels)}")
+    _check(len(exprs) == 15, f"expected 15 exprs, got {len(exprs)}: {sorted(exprs)}")
+    _check(len(thms) == 1, f"expected 1 thm, got {len(thms)}")
+    _check(defs == [] and axs == [], "no defs or axioms in fragment")
+
+
+def test_resolve_name_handles_dotted_and_anon():
+    names, *_ = _load_synthetic()
+    _check(resolve_name(names, 2) == "Foo.bar",
+           f"Foo.bar should round-trip, got {resolve_name(names, 2)!r}")
+    _check(resolve_name(names, 4) == "Pair.fst",
+           f"Pair.fst should round-trip, got {resolve_name(names, 4)!r}")
+    _check(resolve_name(names, 999).startswith("<anon:"),
+           "missing name index should render as <anon:...>")
+
+
+def test_resolve_level_covers_every_kind():
+    names, exprs, levels, *_ = _load_synthetic()
+    # 0 -> "0" (Level.zero is never serialized)
+    _check(resolve_level(names, levels, 0) == "0", "level idx 0 should be '0'")
+    # param u
+    got = resolve_level(names, levels, 1)
+    _check(got == "@u", f"param: expected @u, got {got!r}")
+    # succ (param u)
+    got = resolve_level(names, levels, 2)
+    _check(got == "(succ @u)", f"succ: expected (succ @u), got {got!r}")
+    # max u v
+    got = resolve_level(names, levels, 4)
+    _check(got == "(max @u @v)", f"max: expected (max @u @v), got {got!r}")
+    # imax u v
+    got = resolve_level(names, levels, 5)
+    _check(got == "(imax @u @v)", f"imax: expected (imax @u @v), got {got!r}")
+    # No "<level:N>" placeholder anywhere
+    for idx in (1, 2, 3, 4, 5):
+        rendered = resolve_level(names, levels, idx)
+        _check("<level:" not in rendered, f"unexpected placeholder in {rendered!r}")
+
+
+def test_canonical_expr_renders_literals_and_proj_and_mdata():
+    names, exprs, levels, *_ = _load_synthetic()
+    nat = canonical_expr(names, exprs, levels, 7)
+    _check(nat == "(Lit 42)", f"natVal: expected (Lit 42), got {nat!r}")
+    s = canonical_expr(names, exprs, levels, 8)
+    _check(s == "(LitStr 'hi')", f"strVal: expected (LitStr 'hi'), got {s!r}")
+    proj_render = canonical_expr(names, exprs, levels, 5)
+    _check(proj_render.startswith("(Proj Pair #0 "),
+           f"proj should start '(Proj Pair #0 ', got {proj_render!r}")
+    # mdata is transparent
+    mdata_render = canonical_expr(names, exprs, levels, 6)
+    _check(mdata_render == proj_render,
+           f"mdata should be transparent; got {mdata_render!r} vs {proj_render!r}")
+
+
+def test_canonical_expr_handles_lam_forallE_letE_app():
+    names, exprs, levels, *_ = _load_synthetic()
+    lam = canonical_expr(names, exprs, levels, 12)
+    _check(lam.startswith("(Lam [default] \u03b1 :"),
+           f"lam header wrong: {lam!r}")
+    pi = canonical_expr(names, exprs, levels, 13)
+    _check(pi.startswith("(Pi [default] x :"),
+           f"forallE header wrong: {pi!r}")
+    let_render = canonical_expr(names, exprs, levels, 14)
+    _check(let_render.startswith("(Let y :"), f"letE header wrong: {let_render!r}")
+    app = canonical_expr(names, exprs, levels, 15)
+    _check(app.startswith("(App "), f"app should render as (App ...), got {app!r}")
+
+
+def test_canonicalize_const_full_render_has_no_placeholders():
+    names, exprs, levels, thms, defs, _axs = _load_synthetic()
+    out = canonicalize_const(names, exprs, levels, thms, defs, "Foo.bar")
+    _check(out is not None, "Foo.bar should be found")
+    # The whole point of issue #5: no <level:N> or <unknown:...> placeholders
+    _check("<level:" not in out, f"<level:N> placeholder leaked:\n{out}")
+    _check("<unknown:" not in out, f"<unknown:...> placeholder leaked:\n{out}")
+    # Sanity: each covered feature appears in the rendered text
+    for needle in (
+        "KIND: thm",
+        "@u",                    # param u (in level params and inside max/imax/succ)
+        "@v",                    # param v
+        "(succ @u)",             # Level.succ
+        "(max @u @v)",           # Level.max
+        "(imax @u @v)",          # Level.imax
+        "(Pi [default] x",       # forallE
+        "(Lam [default] \u03b1", # lam
+        "(Let y",                # letE
+        "(Lit 42)",              # natVal
+        "(LitStr 'hi')",         # strVal
+        "(Proj Pair #0 ",        # proj
+        "(Const Pair",           # const + level array
+        "(Const Eq",
+    ):
+        _check(needle in out, f"missing {needle!r} in canonical render:\n{out}")
+    # levelParams render via the name table (not raw indices)
+    _check("LEVEL_PARAMS: ['@u', '@v']" in out,
+           f"levelParams should resolve via name table; got:\n{out}")
+
+
+def test_canonicalize_const_returns_none_for_missing():
+    names, exprs, levels, thms, defs, _axs = _load_synthetic()
+    out = canonicalize_const(names, exprs, levels, thms, defs, "DoesNotExist")
+    _check(out is None, f"missing constant should return None, got {out!r}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = []
+    for t in tests:
+        try:
+            t()
+        except AssertionError as exc:
+            failures.append((t.__name__, str(exc)))
+            print(f"FAIL {t.__name__}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures.append((t.__name__, f"{type(exc).__name__}: {exc}"))
+            print(f"ERROR {t.__name__}: {type(exc).__name__}: {exc}")
+        else:
+            print(f"ok   {t.__name__}")
+    print(textwrap.dedent(f"""
+        ---
+        ran {len(tests)} test(s); {len(failures)} failure(s)
+    """).strip())
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fix the lean4export NDJSON field-name bugs in `scripts/lib/canonical_const_diff.py` (the diagnostic helper from PR #4) and add a unit test to lock the schema in. Verified against `Export.lean` and `format_ndjson.md` on `leanprover/lean4export@master` (format version 3.1.0).

### Bugs fixed

- **Levels** are tagged `"il"`, not `"iu"`. Level subtypes are top-level keys with documented payloads: `"succ"` (int level idx), `"max"`/`"imax"` (`[lhs, rhs]` arrays of level idxs), `"param"` (int *name* idx). Previously every universe rendered as `<level:N>`.
- **Literals** are top-level `"natVal"` (string of digits) and `"strVal"` (string), not nested under `"lit"`. Previously every Nat/String literal rendered as `<unknown:['ie', 'natVal']>`.
- **Axioms** are tagged `"axiom"`, not `"ax"`.
- **`levelParams`** in declarations are arrays of name indices; they now resolve through the name table instead of printing as raw integers.
- **`Expr.const`'s `"us"`** payload was already correct and is preserved.

Each touched branch has an inline comment citing the lean4export field name.

### Test

New `scripts/lib/test_canonical_const_diff.py`: a hand-written synthetic NDJSON fragment exercising every `Level` kind (`succ` / `max` / `imax` / `param`), both literal kinds (`natVal` / `strVal`), `proj`, `mdata`, `lam`, `forallE`, `letE`, `App` spines, and a `thm` declaration that ties them together. Asserts `canonicalize_const` produces output free of `<level:N>` and `<unknown:...>` placeholders. No pytest dependency.

## Test plan

- [x] `python3 scripts/lib/test_canonical_const_diff.py` -- 7/7 pass
- [x] `python3 -c "import ast; ast.parse(open('scripts/lib/canonical_const_diff.py').read())"` -- parses cleanly
- [ ] Reviewer: re-run the diagnostic against the archon-first-proof comparator output and confirm literals/levels render verbatim (no `<level:...>` / `<unknown:...>` lines)

Closes #5

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>